### PR TITLE
Bump version to 1.2.10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The official [Clerk.io](https://clerk.io) plugin for Shopware 6. It connects your store to Clerk.io's AI platform, giving you personalized search, product recommendations, and visitor tracking.
 
-**Version:** 1.2.9 · **PHP:** 7.4+ · **Shopware:** 6.4+
+**Version:** 1.2.10 · **PHP:** 7.4+ · **Shopware:** 6.4+
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "clerkio64/clerkio64",
   "description": "Clerk.io Shopware 6.4+ Plugin",
   "type": "shopware-platform-plugin",
-  "version": "v1.2.9",
+  "version": "v1.2.10",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
Ship the already-merged multilingual language ID fix as a Shopware store release.